### PR TITLE
ci: migrate actions/upload-artifact job from deprecated v2 to v4

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -83,7 +83,7 @@ jobs:
 
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 


### PR DESCRIPTION
When trying to deploy changes to the website, I encountered the following error message in the build job:

`Error: This request has been automatically failed because it uses a deprecated version of 'actions/upload-artifact: v3'. Learn more:` https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/