### PR TITLE
ci: downgrade actions/upload-pages-artifact from v4 to v3

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -83,7 +83,7 @@ jobs:
 
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
Context: Our program is using actions/upload-pages-artifact instead of actions/upload-artifact. The latter has just received a version update to v4, with v3 being deprecated as of 30th January 2025. actions/upload-artifact and actions/upload-pages-artifact are linked to each other, but actions-upload-pages-artifact is one version behind, so the correct updated version of the action for Github Pages is now v3 (and not v4), while its v2 is deprecated.