### PR TITLE
ci: update deploy-pages version to match upload-pages-artifact

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -97,4 +97,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
Now that actions/upload-pages-artifact has been migrated to v3, the build stage is successful but the deploy doesn't find an artifact. From what I can find on this topic on the actions issues, I suspect that it's because upload uses v3 and deploy uses v2