### PR TITLE
ci: update deploy-pages version to latest

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -97,4 +97,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
After updating actions/upload-pages-artifact to v3, neither of actions/deploy-pages@v2 or @v3 work, so I will update deploy-pages to the latest version, v4. This is the setup that the official actions/upload-pages-artifact currently uses: https://github.com/actions/upload-pages-artifact